### PR TITLE
register the filter optimizer in LoadInternal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Registered `PSTFilterOptimizer` in `LoadInternal` rather than `Extension::Load`; the loadable build enters through `DUCKDB_CPP_EXTENSION_ENTRY` and never calls `Load`, so `LOAD pst` had no filter optimizer
+
 ## [0.1.3] - 2026-04-12
 
 - Bumped DuckDB submodule to 1.5.1

--- a/src/pst_extension.cpp
+++ b/src/pst_extension.cpp
@@ -13,6 +13,12 @@ namespace duckdb {
 using namespace intellekt;
 
 static void LoadInternal(ExtensionLoader &loader) {
+  auto &config = DBConfig::GetConfig(loader.GetDatabaseInstance());
+
+  // Has to be here, not in Load: the loadable build enters through
+  // DUCKDB_CPP_EXTENSION_ENTRY, which never calls Load
+  OptimizerExtension::Register(config, duckpst::PSTFilterOptimizer());
+
   TableFunction proto("default", {LogicalType::VARCHAR},
                       duckpst::PSTReadFunction);
 
@@ -47,11 +53,7 @@ static void LoadInternal(ExtensionLoader &loader) {
   }
 }
 
-void PstExtension::Load(ExtensionLoader &loader) {
-  auto &config = DBConfig::GetConfig(loader.GetDatabaseInstance());
-  OptimizerExtension::Register(config, duckpst::PSTFilterOptimizer());
-  LoadInternal(loader);
-}
+void PstExtension::Load(ExtensionLoader &loader) { LoadInternal(loader); }
 
 std::string PstExtension::Name() { return "pst"; }
 


### PR DESCRIPTION
`OptimizerExtension::Register` sat in `PstExtension::Load`, but `DUCKDB_CPP_EXTENSION_ENTRY` expands to a bare function signature and `pst_extension.cpp` supplies the body as `{ LoadInternal(loader); }`. So `Load` never runs under `LOAD pst` and the loadable build had no filter optimizer. The unittest binary links statically and does call `Load`, which is why tests never showed it.

No behaviour change observed. I diffed results and plans between a fixed and unfixed loadable build across nine shapes (equality, LIKE, IN, virtual + real column combined, projection, LIMIT, IS NOT NULL) and they are identical: DuckDB keeps the `FILTER` above the scan anyway, and `prune()` fails open rather than dropping rows. So this restores intent rather than fixing a bug, and there is no assertion that fails before and passes after.

Worth doing because the current behaviour depends on DuckDB continuing to keep a filter it is not obliged to keep.