### PR TITLE
bump microsoft-pst-sdk: non-ascii text failed to decode on macos

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -13,6 +13,7 @@ on:
       - 'vcpkg.json'
       - '.github/workflows/MainDistributionPipeline.yml'
       - 'duckdb'
+      - 'microsoft-pst-sdk'
   pull_request:
     paths:
       - 'src/**'
@@ -23,6 +24,7 @@ on:
       - 'vcpkg.json'
       - '.github/workflows/MainDistributionPipeline.yml'
       - 'duckdb'
+      - 'microsoft-pst-sdk'
   workflow_dispatch:
 
 concurrency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-- Bumped `microsoft-pst-sdk` to `bc1732c`, fixing non-ASCII text on macOS. `bytes_to_wstring` asked iconv for `WCHAR_T`, which follows `LC_CTYPE`, so under a C locale anything above U+007F failed to decode
+- Bumped `microsoft-pst-sdk` to `bc1732c`, fixing non-ASCII text on macOS outside a UTF-8 locale. `bytes_to_wstring` asked iconv for `WCHAR_T`, which macOS resolves through `mbrtowc` and so follows `LC_CTYPE`; with no `LANG` set, as in CI, launchd or a container, anything above U+007F failed to decode. A normal terminal session was unaffected
 - Added in-place deletion: `delete_pst_messages`, `delete_pst_folders`, `delete_pst_attachments` and `wipe_pst_free_space`
   - Gated behind `SET pst_allow_delete = true` and a per-call `really := true`; without `really` the call previews
   - Targets come from a nested read; the input table is positional and checked at bind time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Bumped `microsoft-pst-sdk` to `bc1732c`, fixing non-ASCII text on macOS. `bytes_to_wstring` asked iconv for `WCHAR_T`, which follows `LC_CTYPE`, so under a C locale anything above U+007F failed to decode
 - Added in-place deletion: `delete_pst_messages`, `delete_pst_folders`, `delete_pst_attachments` and `wipe_pst_free_space`
   - Gated behind `SET pst_allow_delete = true` and a per-call `really := true`; without `really` the call previews
   - Targets come from a nested read; the input table is positional and checked at bind time


### PR DESCRIPTION
Picks up intellekthq/microsoft-pst-sdk#6.

`bytes_to_wstring` asked iconv for `WCHAR_T`. macOS resolves that through `mbrtowc`, so it follows `LC_CTYPE`: with no `LANG` set, anything above U+007F came back `EILSEQ`. glibc hardwires `WCHAR_T` to UCS-4 and ignores the locale, so Linux never saw it. The SDK now names `UTF-32LE`, which neither library routes through the locale.

Scope is narrower than "macOS": a terminal session with `LANG=en_US.UTF-8` was fine. It bites where no locale is inherited, which is CI, launchd services, containers and cron.

Reading a body with a right single quote, against the SDK's own fixture:

```sql
select substr(body, 25, 12) as around_quote, strpos(body, chr(8217)) as smart_quote_at
from read_pst_messages('microsoft-pst-sdk/test/sample1.pst') where node_id = 2097188;
┌──────────────┬────────────────┐
│ around_quote │ smart_quote_at │
├──────────────┼────────────────┤
│ . It’s my da │ 29             │
└──────────────┴────────────────┘
```

465 assertions still pass.
