### PR TITLE
fix: use HTTPS for microsoft-pst-sdk submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,4 +8,4 @@
 	branch = main
 [submodule "microsoft-pst-sdk"]
 	path = microsoft-pst-sdk
-	url = git@github.com:intellekt-data/microsoft-pst-sdk.git
+	url = https://github.com/intellekthq/microsoft-pst-sdk.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-08-28
+
+- Switched the `microsoft-pst-sdk` submodule to its public HTTPS URL under the current `intellekthq` organization so anonymous CI runners can initialize it
+
 ## [0.2.0] - 2026-08-03
 
 - Bumped `microsoft-pst-sdk` to `bc1732c`, fixing non-ASCII text on macOS outside a UTF-8 locale. `bytes_to_wstring` asked iconv for `WCHAR_T`, which macOS resolves through `mbrtowc` and so follows `LC_CTYPE`; with no `LANG` set, as in CI, launchd or a container, anything above U+007F failed to decode. A normal terminal session was unaffected
@@ -73,7 +77,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - macOS (x86_64, ARM64)
 - Windows (x86_64)
 
-[Unreleased]: https://github.com/intellekthq/duckdb-pst/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/intellekthq/duckdb-pst/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/intellekthq/duckdb-pst/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/intellekthq/duckdb-pst/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/intellekthq/duckdb-pst/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/intellekthq/duckdb-pst/compare/v0.1.1...v0.1.2


### PR DESCRIPTION
## Summary

- change the microsoft-pst-sdk submodule URL from SSH to HTTPS
- use the current intellekthq organization URL so anonymous CI clones can initialize it
- document the fix as version 0.2.1

Fixes #16

## Validation

- git diff --check origin/main...HEAD
- git config --file .gitmodules --get submodule.microsoft-pst-sdk.url
- git ls-remote https://github.com/intellekthq/microsoft-pst-sdk.git bc1732cb3c4585efb4484ecde4e0d28d51eb3688